### PR TITLE
25 increase default valkey memory limit

### DIFF
--- a/doc/performance.md
+++ b/doc/performance.md
@@ -1,24 +1,31 @@
 # Object-Detector Performance Tuning (i.e. what are our biggest bottlenecks)
 In general, it is quite challenging to saturate even a modest GPU with input data (images).
 
-## Loop times (JPEG mode; order of magnitude; not scientifically tested)
+## Low-Hanging Fruit (all tested with YOLOv8m)
+- TensorRT-optimize the model on the GPU it will be running on (or a very similar one); see object-detector repo for details and code samples -> roughly 200% increase in throughput
+- Do not use standard square inference sizes but restrict to the exact resolution (or rather a multiple of 32 in both dimensions) of the video frames (e.g. 1280x736 for 1280x720 frames) -> roughly 30% increase in throughput for 16:9 frames compared to square
+  - not all configurations benefit from this, but TensorRT does almost linearly (w.r.t. input pixel count)
+- Run multiple object-detectors in parallel to improve GPU usage (one Python process is currently not enough to saturate a RTX A2000) -> roughly 40% increase in throughput
+
+## Detailed performance testing
+### Loop times (JPEG mode; order of magnitude; not scientifically tested)
 - JPEG decoding: 3ms
 - NMS: 1ms
 - Proto deserialization (excluding JPEG decode): 1ms
 - Proto serialization: 1ms
 - Redis send/receive: .5ms each
 
-## Results from performance testing on RTX 3070; YOLO8m (TensorRT-optimized); 1280px
+### Results from performance testing on RTX 3070; YOLO8m (TensorRT-optimized); 1280px
 - roughly 7ms inference time (model without NMS)
 - one instance of object-detector manages a main loop time (redis input -> redis output) of 14ms, i.e. 70fps
 - two instances of object-detector in parallel manage loop times of 22ms, i.e. 45fps each -> 90fps combined
 - even being fed by two instances the GPU is still not saturated
 
-## Tradeoffs and limits
+### Tradeoffs and limits
 - At 100fps and 1280px, we would have to move roughly 5GB/s to the model, which is a lot for network I/O
 - JPEG decoding takes time, but the same goes for network I/O. I have found that it can be roughly equivalent (if we ignore load on redis instance)
 
-## Where to go from here?
+### Where to go from here?
 - Run two models in parallel and investigate the bottlenecks in Python code (CUDA seems to handle two parallel models well enough)
 - Detailed optimization of python code (not sure how much potential is still left)
 - Start to use multiprocessing to feed the GPU (there is torch.multiprocessing) -> multiprocessing in Python is quite complex

--- a/helm/sae/Chart.yaml
+++ b/helm/sae/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.0.0
+version: 5.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/sae/Chart.yaml
+++ b/helm/sae/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.0.1
+version: 5.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/sae/Chart.yaml
+++ b/helm/sae/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.0.0
+version: 5.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/sae/Chart.yaml
+++ b/helm/sae/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.0.2
+version: 6.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/sae/customvalues.template.yaml
+++ b/helm/sae/customvalues.template.yaml
@@ -75,18 +75,19 @@ geoMerger:
 
 redisWriter:
   enabled: false                            # If the redis-writer should be deployed (off by default)
-  config:
-    redis:                                  # The SAE internal Redis instance
-      input_stream_prefix: objecttracker    # The prefix of the input stream (e.g. objecttracker or geomapper)
-    target_redis:                           # The Redis instance to write to
-      host: redis-host
-      port: 6379
-      output_stream_prefix: saeoutput       # The prefix of the output stream (e.g. data will be published to saeoutput:<stream_id>)
-      buffer_length: 10                     # How many messages to buffer before discarding
-      target_stream_maxlen: 100             # How many messages to keep in the output stream (translates to XADD maxlen option)
-      tls: false
-    stream_ids:                             # Which video stream to attach to
-      - stream1
+  configs:                                  # One config per target
+    - name: writer1                         # A unique name to identify the instance
+      redis:                                # The SAE internal Redis instance
+        input_stream_prefix: objecttracker  # The prefix of the input stream (e.g. objecttracker or geomapper)
+      target_redis:                         # The Redis instance to write to
+        host: redis-host
+        port: 6379
+        output_stream_prefix: saeoutput     # The prefix of the output stream (e.g. data will be published to saeoutput:<stream_id>)
+        buffer_length: 10                   # How many messages to buffer before discarding
+        target_stream_maxlen: 100           # How many messages to keep in the output stream (translates to XADD maxlen option)
+        tls: false
+      stream_ids:                           # Which video stream to attach to
+        - stream1
 
 databaseWriter:
   enabled: true                             # If the database-writer should be deployed

--- a/helm/sae/templates/redis-writer.configmap.yaml
+++ b/helm/sae/templates/redis-writer.configmap.yaml
@@ -1,13 +1,15 @@
 {{- with .Values.redisWriter }}
 {{- if .enabled }}
-{{- with .config }}
+{{- range .configs }}
+{{- $instanceName := printf "redis-writer-%s" (lower .name) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redis-writer-config
+  name: {{ $instanceName }}-config
 data:
   settings.yaml: |
     {{- toYaml . | nindent 4 }}
+---
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/sae/templates/redis-writer.statefulset.yaml
+++ b/helm/sae/templates/redis-writer.statefulset.yaml
@@ -2,7 +2,9 @@
 {{- if .enabled }}
 {{- $imageRepo := required "image repository for redis-writer is required" .image.repository }}
 {{- $imageTag := required "image tag for redis-writer is required" .image.tag }}
-{{- $instanceName := "redis-writer" }}
+{{- $rootConfig := . }}
+{{- range .configs -}}
+{{- $instanceName := printf "redis-writer-%s" (lower .name) }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -70,5 +72,6 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm/sae/values.yaml
+++ b/helm/sae/values.yaml
@@ -94,16 +94,19 @@ redisWriter:
     repository: starwitorg/sae-redis-writer
     tag: 1.2.1
   enabled: false
-  config:
-    redis:
-      input_stream_prefix: objecttracker
-    target_redis:
-      output_stream_prefix: saeoutput
-      buffer_length: 10
-      target_stream_maxlen: 100
-      tls: false
-    stream_ids:
-      - stream1
+  configs:
+    - name: output1
+      redis:
+        input_stream_prefix: objecttracker
+      target_redis:
+        output_stream_prefix: saeoutput
+        host: host
+        port: 6379
+        buffer_length: 10
+        target_stream_maxlen: 100
+        tls: false
+      stream_ids:
+        - stream1
 
 databaseWriter:
   image:

--- a/helm/sae/values.yaml
+++ b/helm/sae/values.yaml
@@ -133,6 +133,11 @@ redis:
   master:
     persistence:
       enabled: false
+    resources:
+      limits:
+        memory: 512Mi
+      requests:
+        memory: 256Mi
   metrics:
     enabled: true
 

--- a/helm/sae/values.yaml
+++ b/helm/sae/values.yaml
@@ -26,7 +26,7 @@ objectDetector:
       device: cpu
       nms_agnostic: false
     inference_size: [ 640, 640 ]
-    classes: [ 2 ]
+    classes: null
     redis:
       stream_ids:
         - stream1

--- a/helm/sae/values.yaml
+++ b/helm/sae/values.yaml
@@ -136,8 +136,10 @@ redis:
     resources:
       limits:
         memory: 512Mi
+        cpu: 500m
       requests:
         memory: 256Mi
+        cpu: 250m
   metrics:
     enabled: true
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In high-throughput configurations (i.e. pushing the limits of the hardware) it happens that Valkey is killed, because the default of 192MiB is not sufficient.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
